### PR TITLE
TRP-911 Added minimum age check of 2 days for packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
- Added .npmrc with min-release-age=2 to prevent automatically installing packages less than 2 days old.